### PR TITLE
商品編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_product, only: [:show, :edit, :update]
+  before_action :set_product, only: [:show, :edit, :update, :destroy]
 
   def index
     @products = Product.order(created_at: :desc)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -23,7 +23,6 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    # Ensure the current user is the owner of the product
     redirect_to root_path unless @product.user == current_user
   end
 
@@ -35,6 +34,15 @@ class ProductsController < ApplicationController
     end
   end
 
+  def destroy
+    if @product.user == current_user
+      @product.destroy
+      redirect_to root_path, notice: '商品が削除されました。'
+    else
+      redirect_to root_path, alert: 'この商品を削除する権限がありません。'
+    end
+  end
+
   private
 
   def product_params
@@ -43,5 +51,7 @@ class ProductsController < ApplicationController
 
   def set_product
     @product = Product.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, alert: '商品が見つかりません。'
   end
 end

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,17 +1,12 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @product, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +18,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +28,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +47,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +68,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area_id, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +96,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +136,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', product_path(@product), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>
@@ -153,7 +148,7 @@ app/assets/stylesheets/items/new.css %>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
     <p class="inc">
       ©︎Furima,Inc.
     </p>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -28,8 +28,8 @@
       <% if @product.user == current_user %> <%#&& @product.history.nil?%>
         <%= link_to "商品の編集", edit_product_path(@product), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: { turbo_method: :delete, confirm: "Are you sure?" }, class: "item-destroy" %>
-      <% else %> <%# @product.history.nil? %>
+        <%= link_to "削除", product_path(@product), data: { turbo_method: :delete}, class: "item-destroy" %>
+      <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
     <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,5 +1,4 @@
 <%= render "shared/header" %>
-
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -11,7 +10,6 @@
       <% else %>
         <%= image_tag 'default_image.png', class: "item-box-img" %>
       <% end %>
-
       <% if @product.history.present? %>
         <div class="sold-out">
           <span>Sold Out!!</span>
@@ -26,17 +24,15 @@
         <%= @product.shipping_charge.name %>
       </span>
     </div>
-
     <% if user_signed_in? %>
-      <% if @product.user == current_user %> <%#&& @product.history.nil?%> 
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <% if @product.user == current_user %> <%#&& @product.history.nil?%>
+        <%= link_to "商品の編集", edit_product_path(@product), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: { turbo_method: :delete, confirm: "Are you sure?" }, class: "item-destroy" %>
-      <% elsif %> <%# @product.history.nil? %>
+        <%= link_to "削除", product_path(@product), data: { turbo_method: :delete, confirm: "Are you sure?" }, class: "item-destroy" %>
+      <% else %> <%# @product.history.nil? %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
     <% end %>
-
     <div class="item-explain-box">
       <span>商品説明</span>
       <p><%= @product.description %></p>
@@ -80,7 +76,6 @@
       </div>
     </div>
   </div>
-
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>
@@ -105,5 +100,4 @@
   </div>
   <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
-
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -28,7 +28,7 @@
       <% if @product.user == current_user %> <%#&& @product.history.nil?%>
         <%= link_to "商品の編集", edit_product_path(@product), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", product_path(@product), data: { turbo_method: :delete, confirm: "Are you sure?" }, class: "item-destroy" %>
+        <%= link_to "削除", "#", data: { turbo_method: :delete, confirm: "Are you sure?" }, class: "item-destroy" %>
       <% else %> <%# @product.history.nil? %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
@@ -101,3 +101,7 @@
   <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
 <%= render "shared/footer" %>
+
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products
   devise_for :users
   root to: "products#index"
 end


### PR DESCRIPTION
# What
編集機能の実装


# Why
詳細ページから自分が出品した商品を編集できるようにするため


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
[https://gyazo.com/9f06df160003456a9b776990e03f4d2a](url)

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
[https://gyazo.com/bd69da30dc04749e03cf18a059d2ae3b](url)

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
[https://gyazo.com/0408f764d499a372f5a33762862840ce](url)

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
[https://gyazo.com/c6712c6a95f9f406d71dd0b60b0cdaca](url)

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
[https://gyazo.com/db9f67845e7eb95c96b9c1c038688d0e](url)

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
[https://gyazo.com/fb65bfc6bede5fd1bfcdde3cfa917ecf](url)

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）[](url)
[https://gyazo.com/bd69da30dc04749e03cf18a059d2ae3b](url)