### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -23,7 +23,6 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    # Ensure the current user is the owner of the product
     redirect_to root_path unless @product.user == current_user
   end
 
@@ -35,6 +34,15 @@ class ProductsController < ApplicationController
     end
   end
 
+  def destroy
+    if @product.user == current_user
+      @product.destroy
+      redirect_to root_path, notice: '商品が削除されました。'
+    else
+      redirect_to root_path, alert: 'この商品を削除する権限がありません。'
+    end
+  end
+
   private
 
   def product_params
@@ -43,5 +51,7 @@ class ProductsController < ApplicationController
 
   def set_product
     @product = Product.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, alert: '商品が見つかりません。'
   end
 end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -28,8 +28,8 @@
       <% if @product.user == current_user %> <%#&& @product.history.nil?%>
         <%= link_to "商品の編集", edit_product_path(@product), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: { turbo_method: :delete, confirm: "Are you sure?" }, class: "item-destroy" %>
-      <% else %> <%# @product.history.nil? %>
+        <%= link_to "削除", product_path(@product), data: { turbo_method: :delete}, class: "item-destroy" %>
+      <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products
   devise_for :users
   root to: "products#index"
 end


### PR DESCRIPTION
#what
商品の削除機能を実装


#Why
ログインユーザーのみ商品を削除できるようにし、トップページへ戻ってくるようにする
ため


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[https://gyazo.com/016c306e3f562ecba86704589db3ac42](url)